### PR TITLE
Handle release-triggered downloads deterministically

### DIFF
--- a/.github/workflows/deploy-from-release.yml
+++ b/.github/workflows/deploy-from-release.yml
@@ -26,7 +26,22 @@ jobs:
       - name: Configure Pages
         uses: actions/configure-pages@v5
 
+      - name: Prepare download directory
+        run: |
+          rm -rf download
+          mkdir -p download
+
+      - name: Download release ZIP(s) from event
+        if: github.event_name == 'release'
+        uses: robinraju/release-downloader@v1
+        with:
+          tag: ${{ github.event.release.tag_name }}
+          fileName: '*.zip'          # 不固定檔名：抓所有 zip 資產
+          out-file-path: download
+          extract: true              # 自動解壓到 download/
+
       - name: Download latest release ZIP(s)
+        if: github.event_name != 'release'
         uses: robinraju/release-downloader@v1
         with:
           latest: true


### PR DESCRIPTION
## Summary
- ensure the workflow wipes the download directory before fetching assets
- download the release referenced by the release event instead of relying on the latest release fallback
- retain the latest-release download path for manual dispatch runs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e291b22760832eba9919a6ace3c215